### PR TITLE
Fixed parsing error on signed value as function argument

### DIFF
--- a/bslint/parser/statement_reduction_rules.py
+++ b/bslint/parser/statement_reduction_rules.py
@@ -112,7 +112,9 @@ RULES_LIST = {
             ([const.VALUE, const.MINUS, const.MINUS, const.ID], const.VALUE),
             ([const.FUNCTION_CALL, const.MINUS, const.ID], const.VALUE),
             ([const.FUNCTION_CALL, const.MINUS, const.MINUS, const.ID], const.VALUE),
-            ([const.WHILE, const.MINUS, const.ID], const.WHILE_STMT)
+            ([const.WHILE, const.MINUS, const.ID], const.WHILE_STMT),
+            ([const.MINUS, const.ID], const.VALUE),
+            ([const.PLUS, const.ID], const.VALUE),
         ],
         const.FUNCTION_CALL: [
             ([const.ID, const.COLON, const.FUNCTION_CALL], const.ASSOCIATIVE_ARRAY_ARGUMENT),
@@ -179,6 +181,8 @@ RULES_LIST = {
             ([const.FUNCTION_CALL, const.MINUS, const.VALUE], const.VALUE),
             ([const.FUNCTION_CALL, const.MINUS, const.MINUS, const.VALUE], const.VALUE),
             ([const.WHILE, const.MINUS, const.VALUE], const.WHILE_STMT),
+            ([const.MINUS, const.VALUE], const.VALUE),
+            ([const.PLUS, const.VALUE], const.VALUE),
         ],
         const.ENUMERABLE_OBJECT: [
             ([const.ID, const.COLON, const.ENUMERABLE_OBJECT], const.ASSOCIATIVE_ARRAY_ARGUMENT),

--- a/tests/parse_tests/statement_reduction_tests/value_parse_test.py
+++ b/tests/parse_tests/statement_reduction_tests/value_parse_test.py
@@ -200,6 +200,19 @@ class TestValueParse(unittest.TestCase):
 
     def test_open_parenthesis_value_close_parenthesis(self):
         self.common.match_statement(const.ID, "(1)")
+
+    def test_open_parenthesis_plus_id_close_parenthesis(self):
+        self.common.match_statement(const.ID, "(+y)")
+
+    def test_open_parenthesis_minus_id_close_parenthesis(self):
+        self.common.match_statement(const.ID, "(-y)")
+
+    def test_open_parenthesis_plus_value_close_parenthesis(self):
+        self.common.match_statement(const.ID, "(+1)")
+
+    def test_open_parenthesis_minus_value_close_parenthesis(self):
+        self.common.match_statement(const.ID, "(-1)")
+
     # Only ID Test
 
     def test_open_parenthesis_id_close_parenthesis(self):


### PR DESCRIPTION
Fixed error with: `myvar = myfunc(-1)`